### PR TITLE
request.go: add Extra1/Extra2 to get the extra field for CQE32 flag.

### DIFF
--- a/request.go
+++ b/request.go
@@ -38,6 +38,8 @@ type Result interface {
 	Err() error
 	ReturnValue0() interface{}
 	ReturnValue1() interface{}
+	ReturnExtra1() uint64
+	ReturnExtra2() uint64
 	ReturnFd() (int, error)
 	ReturnInt() (int, error)
 
@@ -64,9 +66,11 @@ type request struct {
 	b1 []byte
 	bs [][]byte
 
-	err error
-	r0  interface{}
-	r1  interface{}
+	err  error
+	r0   interface{}
+	r1   interface{}
+	ext1 uint64
+	ext2 uint64
 
 	requestInfo interface{}
 
@@ -96,6 +100,8 @@ func (req *request) resolve() {
 
 func (req *request) complate(cqe iouring_syscall.CompletionQueueEvent) {
 	req.res = cqe.Result()
+	req.ext1 = cqe.Extra1()
+	req.ext2 = cqe.Extra2()
 	req.iour = nil
 	close(req.done)
 
@@ -172,6 +178,14 @@ func (req *request) ReturnValue0() interface{} {
 func (req *request) ReturnValue1() interface{} {
 	req.resolve()
 	return req.r1
+}
+
+func (req *request) ReturnExtra1() uint64 {
+	return req.ext1
+}
+
+func (req *request) ReturnExtra2() uint64 {
+	return req.ext2
 }
 
 func (req *request) ReturnFd() (int, error) {

--- a/syscall/types.go
+++ b/syscall/types.go
@@ -218,6 +218,8 @@ func (sqe *SubmissionQueueEntry128) CMD(castType interface{}) interface{} {
 type CompletionQueueEvent interface {
 	UserData() uint64
 	Result() int32
+	Extra1() uint64
+	Extra2() uint64
 	Flags() uint32
 	Clone() CompletionQueueEvent
 }
@@ -226,10 +228,6 @@ type cqeCore struct {
 	userData uint64
 	result   int32
 	flags    uint32
-}
-
-func (cqe *cqeCore) copyTo(dest *cqeCore) {
-	*dest = *cqe
 }
 
 func (cqe *cqeCore) UserData() uint64 {
@@ -244,20 +242,43 @@ func (cqe *cqeCore) Flags() uint32 {
 	return cqe.flags
 }
 
-func (cqe *cqeCore) Clone() CompletionQueueEvent {
-	dest := &cqeCore{}
-	cqe.copyTo(dest)
-	return dest
-}
-
 type CompletionQueueEvent16 struct {
 	cqeCore
+}
+
+func (cqe *CompletionQueueEvent16) Extra1() uint64 {
+	return 0
+}
+
+func (cqe *CompletionQueueEvent16) Extra2() uint64 {
+	return 0
+}
+
+func (cqe *CompletionQueueEvent16) Clone() CompletionQueueEvent {
+	dest := &CompletionQueueEvent16{}
+	*dest = *cqe
+	return dest
 }
 
 type CompletionQueueEvent32 struct {
 	cqeCore
 
-	data [16]uint8
+	extra1 uint64
+	extra2 uint64
+}
+
+func (cqe *CompletionQueueEvent32) Extra1() uint64 {
+	return cqe.extra1
+}
+
+func (cqe *CompletionQueueEvent32) Extra2() uint64 {
+	return cqe.extra2
+}
+
+func (cqe *CompletionQueueEvent32) Clone() CompletionQueueEvent {
+	dest := &CompletionQueueEvent32{}
+	*dest = *cqe
+	return dest
 }
 
 const IORING_FSYNC_DATASYNC uint32 = 1


### PR DESCRIPTION
for the extra return value from pass-through command, add extra field to Request and CompletionQueueEvent and its structures. Different from the res, r0, and r1 field, these extra field should be managed by their pass-through device's specification. So, just pass the extra field from CQE to iouring-go's application.